### PR TITLE
React.memo optimization demo

### DIFF
--- a/src/graphs/Area.tsx
+++ b/src/graphs/Area.tsx
@@ -30,4 +30,5 @@ const Area = ({ className, data, scales }: Props) => {
   return <path className={`area ${className}`} d={d} />;
 };
 
-export default React.memo(Area);
+export default Area;
+// export default React.memo(Area);

--- a/src/graphs/Axis.tsx
+++ b/src/graphs/Axis.tsx
@@ -72,4 +72,5 @@ const Axis = ({ orient, scale }: Props) => {
   return <g className="axis" ref={axisRef} transform={transform} />;
 };
 
-export default React.memo(Axis);
+export default Axis;
+// export default React.memo(Axis);

--- a/src/graphs/MouseLine.tsx
+++ b/src/graphs/MouseLine.tsx
@@ -39,4 +39,5 @@ const MouseLine = ({ mousePos }: Props) => {
   return null;
 };
 
-export default React.memo(MouseLine);
+export default MouseLine;
+// export default React.memo(MouseLine);


### PR DESCRIPTION
This is a PR to demonstrate how `React.memo` can affect component rendering.

Run the application with or without `React.memo` (switch between `main` and this branch) and observe the difference.

![without-react-memo](https://user-images.githubusercontent.com/36203857/127697067-e7d5f5d0-df56-4436-8fc2-7e3307c6a4e8.gif)
As you can see in the gif above, it appears that there is a slight lagging on the two mouse lines (vertical and horizontal) when `React.memo` is not being used.
